### PR TITLE
Export fromEnv function

### DIFF
--- a/dotconfig.go
+++ b/dotconfig.go
@@ -156,7 +156,7 @@ var (
 	ErrUnsupportedFieldType = errors.New("unsupported field type")
 )
 
-func fromEnv[T any](opts options) (T, error) {
+func FromEnv[T any](opts options) (T, error) {
 	var config T
 	errs := joinError{}
 	// Reflect into our config


### PR DESCRIPTION
This function is useful in combination with other config and env loading libs. I can copy it in my code with license, but i think it would be better if you export this function too.